### PR TITLE
Remove remix build command from dev script

### DIFF
--- a/3-deployment-targets-adapters-and-stacks/bee-rich/package.json
+++ b/3-deployment-targets-adapters-and-stacks/bee-rich/package.json
@@ -8,7 +8,7 @@
     "build": "run-s \"build:*\"",
     "build:css": "npm run generate:css -- --minify",
     "build:remix": "remix build",
-    "dev": "remix build && run-p \"dev:*\"",
+    "dev": "run-p \"dev:*\"",
     "dev:css": "npm run generate:css -- --watch",
     "dev:node": "cross-env NODE_ENV=development nodemon ./server.js --watch ./server.js",
     "dev:remix": "remix watch",

--- a/3-deployment-targets-adapters-and-stacks/using-remix-stacks/package-lock.json
+++ b/3-deployment-targets-adapters-and-stacks/using-remix-stacks/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "indie-stack-template",
+  "name": "using-remix-stacks-4ce2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "indie-stack-template",
+      "name": "using-remix-stacks-4ce2",
       "dependencies": {
         "@prisma/client": "^4.3.1",
         "@remix-run/node": "^1.7.4",

--- a/4-routing-in-remix/bee-rich/package.json
+++ b/4-routing-in-remix/bee-rich/package.json
@@ -8,7 +8,7 @@
     "build": "run-s \"build:*\"",
     "build:css": "npm run generate:css -- --minify",
     "build:remix": "remix build",
-    "dev": "remix build && run-p \"dev:*\"",
+    "dev": "run-p \"dev:*\"",
     "dev:css": "npm run generate:css -- --watch",
     "dev:node": "cross-env NODE_ENV=development nodemon ./server.js --watch ./server.js",
     "dev:remix": "remix watch",


### PR DESCRIPTION
Removing `remix build` from `dev` command in the `bee-rich` apps

Previously running `npm run dev` the first time would result in the following error, since `styles/tailwind.css` hasn't yet been created:

![image](https://user-images.githubusercontent.com/12396812/201689609-b5f03a5b-7c3e-4e1f-b0f7-5c721c3e81b2.png)

Note: with this fix you still get an error, but it does not crash the dev server and quickly resolves itself. If we want to avoid getting this error at all, we should either add `npm run build` or a simple `touch app/styles/tailwind.css` at the beginning of the script.

![image](https://user-images.githubusercontent.com/12396812/201689903-8ff724ff-60bf-4891-b7ec-6a3e5d1d2f82.png)
