### PR TITLE
Use `ts-node` instead of `bun` to run db `seed.ts` script

### DIFF
--- a/05-fetching-and-mutating-data/bee-rich/README.md
+++ b/05-fetching-and-mutating-data/bee-rich/README.md
@@ -167,7 +167,7 @@ Usually you can import the Prisma client directly from `@prisma/client`. However
 Create a new file `db.server.ts` in the `app` folder and add the following code:
 
 ```ts
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from '@prisma/client';
 
 let db: PrismaClient;
 
@@ -179,7 +179,7 @@ declare global {
 // this is needed because in development we don't want to restart
 // the server with every change, but we want to make sure we don't
 // create a new connection to the DB with every change either.
-if (process.env.NODE_ENV === "production") {
+if (process.env.NODE_ENV === 'production') {
   db = new PrismaClient();
 } else {
   if (!global.__db) {
@@ -189,6 +189,7 @@ if (process.env.NODE_ENV === "production") {
 }
 
 export { db };
+
 ```
 
 You can find more information about this wrapper in the database section of the [Remix Jokes App Tutorial](https://remix.run/docs/en/v1/tutorials/jokes#connect-to-the-database).
@@ -198,151 +199,151 @@ You can find more information about this wrapper in the database section of the 
 Create a new file `seed.ts` in the `prisma` folder and add the following code:
 
 ```ts
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient } from '@prisma/client';
 
 const db = new PrismaClient();
 
 const expenses = [
   {
-    title: "Groceries",
+    title: 'Groceries',
     amount: 50,
-    currencyCode: "USD",
-    date: "2022-12-05",
+    currencyCode: 'USD',
+    date: '2022-12-05',
   },
   {
-    title: "Gym Membership",
+    title: 'Gym Membership',
     amount: 20,
-    currencyCode: "USD",
-    date: "2022-12-03",
+    currencyCode: 'USD',
+    date: '2022-12-03',
   },
   {
-    title: "Movies",
+    title: 'Movies',
     amount: 20,
-    currencyCode: "USD",
-    date: "2022-12-02",
+    currencyCode: 'USD',
+    date: '2022-12-02',
   },
   {
-    title: "Mobile Service",
+    title: 'Mobile Service',
     amount: 55,
-    currencyCode: "USD",
-    date: "2022-11-01",
+    currencyCode: 'USD',
+    date: '2022-11-01',
   },
   {
-    title: "Rent December",
+    title: 'Rent December',
     amount: 1000,
-    currencyCode: "USD",
-    date: "2022-12-01",
+    currencyCode: 'USD',
+    date: '2022-12-01',
   },
   {
-    title: "Groceries",
+    title: 'Groceries',
     amount: 55,
-    currencyCode: "USD",
-    date: "2022-12-01",
+    currencyCode: 'USD',
+    date: '2022-12-01',
   },
   {
-    title: "Takeout",
+    title: 'Takeout',
     amount: 55,
-    currencyCode: "USD",
-    date: "2022-11-30",
+    currencyCode: 'USD',
+    date: '2022-11-30',
   },
   {
-    title: "Gym Membership",
+    title: 'Gym Membership',
     amount: 20,
-    currencyCode: "USD",
-    date: "2022-11-03",
+    currencyCode: 'USD',
+    date: '2022-11-03',
   },
   {
-    title: "Groceries",
+    title: 'Groceries',
     amount: 15,
-    currencyCode: "USD",
-    date: "2022-11-02",
+    currencyCode: 'USD',
+    date: '2022-11-02',
   },
   {
-    title: "Mobile Service",
+    title: 'Mobile Service',
     amount: 55,
-    currencyCode: "USD",
-    date: "2022-11-01",
+    currencyCode: 'USD',
+    date: '2022-11-01',
   },
   {
-    title: "Rent November",
+    title: 'Rent November',
     amount: 1000,
-    currencyCode: "USD",
-    date: "2022-11-01",
+    currencyCode: 'USD',
+    date: '2022-11-01',
   },
   {
-    title: "Groceries",
+    title: 'Groceries',
     amount: 55,
-    currencyCode: "USD",
-    date: "2022-10-30",
+    currencyCode: 'USD',
+    date: '2022-10-30',
   },
   {
-    title: "Groceries",
+    title: 'Groceries',
     amount: 55,
-    currencyCode: "USD",
-    date: "2022-10-15",
+    currencyCode: 'USD',
+    date: '2022-10-15',
   },
   {
-    title: "Dinner",
+    title: 'Dinner',
     amount: 40,
-    currencyCode: "USD",
-    date: "2022-10-11",
+    currencyCode: 'USD',
+    date: '2022-10-11',
   },
   {
-    title: "Gym Membership",
+    title: 'Gym Membership',
     amount: 20,
-    currencyCode: "USD",
-    date: "2022-10-03",
+    currencyCode: 'USD',
+    date: '2022-10-03',
   },
   {
-    title: "Groceries",
+    title: 'Groceries',
     amount: 25,
-    currencyCode: "USD",
-    date: "2022-10-02",
+    currencyCode: 'USD',
+    date: '2022-10-02',
   },
   {
-    title: "Mobile Service",
+    title: 'Mobile Service',
     amount: 55,
-    currencyCode: "USD",
-    date: "2022-10-01",
+    currencyCode: 'USD',
+    date: '2022-10-01',
   },
   {
-    title: "Rent October",
+    title: 'Rent October',
     amount: 1000,
-    currencyCode: "USD",
-    date: "2022-10-01",
+    currencyCode: 'USD',
+    date: '2022-10-01',
   },
   {
-    title: "Groceries",
+    title: 'Groceries',
     amount: 55,
-    currencyCode: "USD",
-    date: "2022-10-01",
+    currencyCode: 'USD',
+    date: '2022-10-01',
   },
 ];
 
 const income = [
   {
-    title: "Salary December",
+    title: 'Salary December',
     amount: 2500,
-    currencyCode: "USD",
-    date: "2022-12-30",
+    currencyCode: 'USD',
+    date: '2022-12-30',
   },
   {
-    title: "Salary November",
+    title: 'Salary November',
     amount: 2500,
-    currencyCode: "USD",
-    date: "2022-11-30",
+    currencyCode: 'USD',
+    date: '2022-11-30',
   },
   {
-    title: "Salary October",
+    title: 'Salary October',
     amount: 2500,
-    currencyCode: "USD",
-    date: "2022-10-30",
+    currencyCode: 'USD',
+    date: '2022-10-30',
   },
   {
-    title: "Salary September",
+    title: 'Salary September',
     amount: 2500,
-    currencyCode: "USD",
-    date: "2022-09-30",
+    currencyCode: 'USD',
+    date: '2022-09-30',
   },
 ];
 
@@ -368,13 +369,14 @@ function createInvoice(incomeData: (typeof income)[number]) {
   });
 }
 
-console.log("🌱 Seeding the database...");
+console.log('🌱 Seeding the database...');
 const start = performance.now();
 const expensePromises = expenses.map((expense) => createExpense(expense));
 const invoicePromises = income.map((income) => createInvoice(income));
 await Promise.all([...expensePromises, ...invoicePromises]);
 const end = performance.now();
 console.log(`🚀 Seeded the database. Done in ${Math.round(end - start)}ms`);
+
 ```
 
 This script is used to seed the database with sample data. We can execute the script by running the following command:

--- a/05-fetching-and-mutating-data/bee-rich/README.md
+++ b/05-fetching-and-mutating-data/bee-rich/README.md
@@ -99,7 +99,7 @@ You can find the extension in the [VSCode marketplace](https://marketplace.visua
   "format:db": "npx prisma format",
   "build:db": "npx prisma generate",
   "update:db": "npx prisma db push",
-  "seed": "bun prisma/seed.ts",
+  "seed": "npx ts-node --esm prisma/seed.ts",
   "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed"
 }
 ```
@@ -167,7 +167,7 @@ Usually you can import the Prisma client directly from `@prisma/client`. However
 Create a new file `db.server.ts` in the `app` folder and add the following code:
 
 ```ts
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from "@prisma/client";
 
 let db: PrismaClient;
 
@@ -179,7 +179,7 @@ declare global {
 // this is needed because in development we don't want to restart
 // the server with every change, but we want to make sure we don't
 // create a new connection to the DB with every change either.
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV === "production") {
   db = new PrismaClient();
 } else {
   if (!global.__db) {
@@ -189,7 +189,6 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 export { db };
-
 ```
 
 You can find more information about this wrapper in the database section of the [Remix Jokes App Tutorial](https://remix.run/docs/en/v1/tutorials/jokes#connect-to-the-database).
@@ -199,151 +198,151 @@ You can find more information about this wrapper in the database section of the 
 Create a new file `seed.ts` in the `prisma` folder and add the following code:
 
 ```ts
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from "@prisma/client";
 
 const db = new PrismaClient();
 
 const expenses = [
   {
-    title: 'Groceries',
+    title: "Groceries",
     amount: 50,
-    currencyCode: 'USD',
-    date: '2022-12-05',
+    currencyCode: "USD",
+    date: "2022-12-05",
   },
   {
-    title: 'Gym Membership',
+    title: "Gym Membership",
     amount: 20,
-    currencyCode: 'USD',
-    date: '2022-12-03',
+    currencyCode: "USD",
+    date: "2022-12-03",
   },
   {
-    title: 'Movies',
+    title: "Movies",
     amount: 20,
-    currencyCode: 'USD',
-    date: '2022-12-02',
+    currencyCode: "USD",
+    date: "2022-12-02",
   },
   {
-    title: 'Mobile Service',
+    title: "Mobile Service",
     amount: 55,
-    currencyCode: 'USD',
-    date: '2022-11-01',
+    currencyCode: "USD",
+    date: "2022-11-01",
   },
   {
-    title: 'Rent December',
+    title: "Rent December",
     amount: 1000,
-    currencyCode: 'USD',
-    date: '2022-12-01',
+    currencyCode: "USD",
+    date: "2022-12-01",
   },
   {
-    title: 'Groceries',
+    title: "Groceries",
     amount: 55,
-    currencyCode: 'USD',
-    date: '2022-12-01',
+    currencyCode: "USD",
+    date: "2022-12-01",
   },
   {
-    title: 'Takeout',
+    title: "Takeout",
     amount: 55,
-    currencyCode: 'USD',
-    date: '2022-11-30',
+    currencyCode: "USD",
+    date: "2022-11-30",
   },
   {
-    title: 'Gym Membership',
+    title: "Gym Membership",
     amount: 20,
-    currencyCode: 'USD',
-    date: '2022-11-03',
+    currencyCode: "USD",
+    date: "2022-11-03",
   },
   {
-    title: 'Groceries',
+    title: "Groceries",
     amount: 15,
-    currencyCode: 'USD',
-    date: '2022-11-02',
+    currencyCode: "USD",
+    date: "2022-11-02",
   },
   {
-    title: 'Mobile Service',
+    title: "Mobile Service",
     amount: 55,
-    currencyCode: 'USD',
-    date: '2022-11-01',
+    currencyCode: "USD",
+    date: "2022-11-01",
   },
   {
-    title: 'Rent November',
+    title: "Rent November",
     amount: 1000,
-    currencyCode: 'USD',
-    date: '2022-11-01',
+    currencyCode: "USD",
+    date: "2022-11-01",
   },
   {
-    title: 'Groceries',
+    title: "Groceries",
     amount: 55,
-    currencyCode: 'USD',
-    date: '2022-10-30',
+    currencyCode: "USD",
+    date: "2022-10-30",
   },
   {
-    title: 'Groceries',
+    title: "Groceries",
     amount: 55,
-    currencyCode: 'USD',
-    date: '2022-10-15',
+    currencyCode: "USD",
+    date: "2022-10-15",
   },
   {
-    title: 'Dinner',
+    title: "Dinner",
     amount: 40,
-    currencyCode: 'USD',
-    date: '2022-10-11',
+    currencyCode: "USD",
+    date: "2022-10-11",
   },
   {
-    title: 'Gym Membership',
+    title: "Gym Membership",
     amount: 20,
-    currencyCode: 'USD',
-    date: '2022-10-03',
+    currencyCode: "USD",
+    date: "2022-10-03",
   },
   {
-    title: 'Groceries',
+    title: "Groceries",
     amount: 25,
-    currencyCode: 'USD',
-    date: '2022-10-02',
+    currencyCode: "USD",
+    date: "2022-10-02",
   },
   {
-    title: 'Mobile Service',
+    title: "Mobile Service",
     amount: 55,
-    currencyCode: 'USD',
-    date: '2022-10-01',
+    currencyCode: "USD",
+    date: "2022-10-01",
   },
   {
-    title: 'Rent October',
+    title: "Rent October",
     amount: 1000,
-    currencyCode: 'USD',
-    date: '2022-10-01',
+    currencyCode: "USD",
+    date: "2022-10-01",
   },
   {
-    title: 'Groceries',
+    title: "Groceries",
     amount: 55,
-    currencyCode: 'USD',
-    date: '2022-10-01',
+    currencyCode: "USD",
+    date: "2022-10-01",
   },
 ];
 
 const income = [
   {
-    title: 'Salary December',
+    title: "Salary December",
     amount: 2500,
-    currencyCode: 'USD',
-    date: '2022-12-30',
+    currencyCode: "USD",
+    date: "2022-12-30",
   },
   {
-    title: 'Salary November',
+    title: "Salary November",
     amount: 2500,
-    currencyCode: 'USD',
-    date: '2022-11-30',
+    currencyCode: "USD",
+    date: "2022-11-30",
   },
   {
-    title: 'Salary October',
+    title: "Salary October",
     amount: 2500,
-    currencyCode: 'USD',
-    date: '2022-10-30',
+    currencyCode: "USD",
+    date: "2022-10-30",
   },
   {
-    title: 'Salary September',
+    title: "Salary September",
     amount: 2500,
-    currencyCode: 'USD',
-    date: '2022-09-30',
+    currencyCode: "USD",
+    date: "2022-09-30",
   },
 ];
 
@@ -369,14 +368,13 @@ function createInvoice(incomeData: (typeof income)[number]) {
   });
 }
 
-console.log('🌱 Seeding the database...');
+console.log("🌱 Seeding the database...");
 const start = performance.now();
 const expensePromises = expenses.map((expense) => createExpense(expense));
 const invoicePromises = income.map((income) => createInvoice(income));
 await Promise.all([...expensePromises, ...invoicePromises]);
 const end = performance.now();
 console.log(`🚀 Seeded the database. Done in ${Math.round(end - start)}ms`);
-
 ```
 
 This script is used to seed the database with sample data. We can execute the script by running the following command:

--- a/05-fetching-and-mutating-data/bee-rich/solution/package.json
+++ b/05-fetching-and-mutating-data/bee-rich/solution/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/05-fetching-and-mutating-data/bee-rich/start/package.json
+++ b/05-fetching-and-mutating-data/bee-rich/start/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/06-enhancing-the-user-experience/bee-rich/solution/package.json
+++ b/06-enhancing-the-user-experience/bee-rich/solution/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/06-enhancing-the-user-experience/bee-rich/start/package.json
+++ b/06-enhancing-the-user-experience/bee-rich/start/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/07-error-handling-in-remix/bee-rich/solution/package.json
+++ b/07-error-handling-in-remix/bee-rich/solution/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/08-session-management/bee-rich/solution/package.json
+++ b/08-session-management/bee-rich/solution/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/08-session-management/bee-rich/start/package.json
+++ b/08-session-management/bee-rich/start/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/09-assets-and-meta-data-handling/bee-rich/solution/package.json
+++ b/09-assets-and-meta-data-handling/bee-rich/solution/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/10-working-with-file-uploads/bee-rich/solution/package.json
+++ b/10-working-with-file-uploads/bee-rich/solution/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/10-working-with-file-uploads/bee-rich/start/package.json
+++ b/10-working-with-file-uploads/bee-rich/start/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/11-optimistic-ui/bee-rich/solution/package.json
+++ b/11-optimistic-ui/bee-rich/solution/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/11-optimistic-ui/bee-rich/start/package-lock.json
+++ b/11-optimistic-ui/bee-rich/start/package-lock.json
@@ -47,7 +47,6 @@
         "prisma": "^5.3.1",
         "rimraf": "^5.0.1",
         "tailwindcss": "^3.3.3",
-        "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       },
       "engines": {
@@ -904,28 +903,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@emotion/hash": {
@@ -2104,30 +2081,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
-    },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
@@ -2702,15 +2655,6 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -3615,12 +3559,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "node_modules/cross-env": {
@@ -6966,12 +6904,6 @@
       "bin": {
         "lz-string": "bin/bin.js"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
     },
     "node_modules/markdown-extensions": {
       "version": "1.1.1",
@@ -10836,64 +10768,6 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/ts-node/node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
-    },
-    "node_modules/ts-node/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz",
@@ -11322,12 +11196,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -12151,15 +12019,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -12817,27 +12676,6 @@
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.5",
         "to-fast-properties": "^2.0.0"
-      }
-    },
-    "@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "dependencies": {
-        "@jridgewell/trace-mapping": {
-          "version": "0.3.9",
-          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/resolve-uri": "^3.0.3",
-            "@jridgewell/sourcemap-codec": "^1.4.10"
-          }
-        }
       }
     },
     "@emotion/hash": {
@@ -13593,30 +13431,6 @@
         "pretty-format": "^27.0.2"
       }
     },
-    "@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
-    },
-    "@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
-    },
     "@types/acorn": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
@@ -14084,12 +13898,6 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
-    },
-    "acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -14731,12 +14539,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true
-    },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "cross-env": {
@@ -17184,12 +16986,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "dev": true
-    },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "markdown-extensions": {
@@ -19960,41 +19756,6 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
-    "ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "requires": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "dependencies": {
-        "arg": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-          "dev": true
-        },
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true
-        }
-      }
-    },
     "tsconfig-paths": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz",
@@ -20293,12 +20054,6 @@
         "kleur": "^4.0.3",
         "sade": "^1.7.3"
       }
-    },
-    "v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -20773,12 +20528,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
       "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
-      "dev": true
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
     "yocto-queue": {

--- a/11-optimistic-ui/bee-rich/start/package-lock.json
+++ b/11-optimistic-ui/bee-rich/start/package-lock.json
@@ -47,6 +47,7 @@
         "prisma": "^5.3.1",
         "rimraf": "^5.0.1",
         "tailwindcss": "^3.3.3",
+        "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
       },
       "engines": {
@@ -903,6 +904,28 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@emotion/hash": {
@@ -2081,6 +2104,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "node_modules/@types/acorn": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
@@ -2655,6 +2702,15 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -3559,6 +3615,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "node_modules/cross-env": {
@@ -6904,6 +6966,12 @@
       "bin": {
         "lz-string": "bin/bin.js"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/markdown-extensions": {
       "version": "1.1.1",
@@ -10768,6 +10836,64 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz",
@@ -11196,6 +11322,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -12019,6 +12151,15 @@
         "node": ">= 14"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -12676,6 +12817,27 @@
         "@babel/helper-string-parser": "^7.22.5",
         "@babel/helper-validator-identifier": "^7.22.5",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+          "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
       }
     },
     "@emotion/hash": {
@@ -13431,6 +13593,30 @@
         "pretty-format": "^27.0.2"
       }
     },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true
+    },
     "@types/acorn": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
@@ -13898,6 +14084,12 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "requires": {}
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -14539,6 +14731,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
     "cross-env": {
@@ -16986,6 +17184,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
     },
     "markdown-extensions": {
@@ -19756,6 +19960,41 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "arg": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+          "dev": true
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz",
@@ -20054,6 +20293,12 @@
         "kleur": "^4.0.3",
         "sade": "^1.7.3"
       }
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -20528,6 +20773,12 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
       "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     },
     "yocto-queue": {

--- a/11-optimistic-ui/bee-rich/start/package.json
+++ b/11-optimistic-ui/bee-rich/start/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/11-optimistic-ui/bee-rich/start/package.json
+++ b/11-optimistic-ui/bee-rich/start/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node-esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",
@@ -63,6 +63,7 @@
     "prisma": "^5.3.1",
     "rimraf": "^5.0.1",
     "tailwindcss": "^3.3.3",
+    "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   },
   "engines": {

--- a/11-optimistic-ui/bee-rich/start/package.json
+++ b/11-optimistic-ui/bee-rich/start/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "npx ts-node-esm prisma/seed.ts",
+    "seed": "bun prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",
@@ -63,7 +63,6 @@
     "prisma": "^5.3.1",
     "rimraf": "^5.0.1",
     "tailwindcss": "^3.3.3",
-    "ts-node": "^10.9.1",
     "typescript": "^5.2.2"
   },
   "engines": {

--- a/12-caching-strategies/bee-rich/solution/package.json
+++ b/12-caching-strategies/bee-rich/solution/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/13-deferring-loader-data/bee-rich/solution/package.json
+++ b/13-deferring-loader-data/bee-rich/solution/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/13-deferring-loader-data/bee-rich/start/package.json
+++ b/13-deferring-loader-data/bee-rich/start/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/14-real-time-with-remix/bee-rich/solution/package.json
+++ b/14-real-time-with-remix/bee-rich/solution/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "bun prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/15-advanced-session-management/bee-rich/solution/package.json
+++ b/15-advanced-session-management/bee-rich/solution/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "npx npx ts-node --esm prisma/seed.ts",
+    "seed": "npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",

--- a/15-advanced-session-management/bee-rich/solution/package.json
+++ b/15-advanced-session-management/bee-rich/solution/package.json
@@ -15,7 +15,7 @@
     "build:db": "npx prisma generate",
     "update:db": "npx prisma db push",
     "update:remix": "npm i @remix-run/express@2 @remix-run/node@2 @remix-run/react@2 @remix-run/dev@2 @remix-run/eslint-config@2 @remix-run/css-bundle@2",
-    "seed": "npx bun prisma/seed.ts",
+    "seed": "npx npx ts-node --esm prisma/seed.ts",
     "reset:db": "rimraf ./prisma/dev.db && npm run update:db && npm run seed",
     "dev": "run-p \"dev:*\"",
     "dev:remix": "remix dev --manual -c \"node server.js\"",


### PR DESCRIPTION
## Summary

Use `ts-node` instead of `bun` to run db `seed.ts` script.

## Details

The current db `seed.ts` script uses `bun`, which readers may not have installed. Using `ts-node` instead will be more familiar to readers since it's part of the node ecosystem.

Changes made:

- Replace `bun prisma/seed.ts` with `npx ts-node --esm prisma/seed.ts` across the project.

## Notes

`ts-node` can be used to run esm modules via the following methods:

```sh
# pass the flag
ts-node --esm

# Use the convenience binary
ts-node-esm

# or add `"esm": true` to your tsconfig.json to make it automatic
ts-node
```

I chose the flag option so that we don't have to install `ts-node` as a dependency nor update the `tsconfig.json`. For more details, please see the `ts-node` [docs](https://typestrong.org/ts-node/docs/imports/#native-ecmascript-modules).