### PR TITLE
Fix typo in Chapter 11 README

### DIFF
--- a/11-optimistic-ui/bee-rich/README.md
+++ b/11-optimistic-ui/bee-rich/README.md
@@ -61,7 +61,7 @@ This is optional, but can be helpful for testing.
 
 Test credentials:
 
-- Email: john.doe@example.com'
+- Email: john.doe@example.com
 - Password: BeeRich
 
 You can also update the seed data in `prisma/seed.ts`.


### PR DESCRIPTION
## Summary

Fix typo in README. Remove extra trailing `'` on line 64:

Change
`- Email: john.doe@example.com'`
To 
`- Email: john.doe@example.com`
 